### PR TITLE
compilation patch (Ubuntu 20.10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ SRCS := $(wildcard $(SRC_DIR)/*.c)
 OBJS := $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
 
 .PHONY: all
-all: $(OBJS)
+all: $(MAIN)
+
+$(MAIN): $(OBJS)
 	$(CC) -o $(MAIN) $? $(CFLAGS_1) $(LIBS)
 
 
@@ -23,5 +25,5 @@ $(OBJS): $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(INCLUDES)
 	$(CC) -c -o $@ $< $(LIBS) $(CFLAGS_1)
 
 clean:
-	rm bin/main
-	rm lib/*.o
+	rm -f bin/main
+	rm -f lib/*.o

--- a/include/capture.h
+++ b/include/capture.h
@@ -16,8 +16,8 @@ typedef struct {
 	unsigned channels;
 } capHW;
 
-capHW hw;
-int err;
+extern capHW hw;
+extern int err;
 
 void loadCapSettings(const char name[], const unsigned sr, const unsigned c);
 

--- a/include/gui.h
+++ b/include/gui.h
@@ -9,13 +9,13 @@
 #include <ncurses.h>
 
 // Windows
-WINDOW *selectorContainer;
-WINDOW *selector;
+extern WINDOW *selectorContainer;
+extern WINDOW *selector;
 
 // Geometrical features
-int LEN_CONTAINER, POSX_CONTAINER;
-int LEN_SELECTOR, POSX0_SELECTOR, POSX1_SELECTOR, POSX2_SELECTOR; 
-int POSX_STEREO, POSX_FRONT, POSX_SURROUND; 
+extern int LEN_CONTAINER, POSX_CONTAINER;
+extern int LEN_SELECTOR, POSX0_SELECTOR, POSX1_SELECTOR, POSX2_SELECTOR; 
+extern int POSX_STEREO, POSX_FRONT, POSX_SURROUND; 
 
 void initGui(char const *dev_names[]);		// init interface
 void refreshGui();	// updates screen

--- a/include/playback.h
+++ b/include/playback.h
@@ -17,8 +17,7 @@ typedef struct {
 	long unsigned frames;
 } PlaybackHW;
 
-PlaybackHW hwpb;
-int err;
+extern PlaybackHW hwpb;
 
 void loadPBSettings(const char name[], const unsigned sr, const unsigned c, const unsigned f);
 snd_pcm_t * playbackSetup();

--- a/include/task.h
+++ b/include/task.h
@@ -13,15 +13,15 @@
 #include <alsa/asoundlib.h>
 
 // Alsa handlers
-snd_pcm_t *cHandle;			// capture handler
-snd_pcm_t *pbHandle;		// playback handler
+extern snd_pcm_t *cHandle;			// capture handler
+extern snd_pcm_t *pbHandle;		// playback handler
 
 // Variables
-short bufRead[CHANNELS * M];	// buffer for capturing
-short bufWrite[CHANNELS * M];	// buffer for playback
-int readData, writeData;		// number of samples captured
+extern short bufRead[CHANNELS * M];	// buffer for capturing
+extern short bufWrite[CHANNELS * M];	// buffer for playback
+extern int readData, writeData;		// number of samples captured
 
-struct BufferSem inBufferSem, outBufferSem;	// to synch tasks
+extern struct BufferSem inBufferSem, outBufferSem;	// to synch tasks
 
 extern unsigned short exitLoop;
 extern unsigned char toggle;

--- a/src/capture.c
+++ b/src/capture.c
@@ -8,6 +8,9 @@
 
 #include "capture.h"
 
+capHW hw;
+int err;
+
 void loadCapSettings(const char name[], const unsigned sr, const unsigned c){
 	strcpy(hw.name, name);
 	hw.samplerate = sr;

--- a/src/gui.c
+++ b/src/gui.c
@@ -8,6 +8,15 @@
 
 #include <ncurses.h>
 
+// Windows
+WINDOW *selectorContainer;
+WINDOW *selector;
+
+// Geometrical features
+int LEN_CONTAINER, POSX_CONTAINER;
+int LEN_SELECTOR, POSX0_SELECTOR, POSX1_SELECTOR, POSX2_SELECTOR; 
+int POSX_STEREO, POSX_FRONT, POSX_SURROUND; 
+
 void computeGeometricalParams(){
 	// Geometry for Container
 	LEN_CONTAINER = COLS / 3;

--- a/src/playback.c
+++ b/src/playback.c
@@ -8,6 +8,8 @@
 #include <sys/time.h>
 #include "playback.h"
 
+PlaybackHW hwpb;
+
 void loadPBSettings(const char name[], const unsigned sr, const unsigned c, const unsigned f) {
 	strcpy(hwpb.name, name);
 	hwpb.samplerate = sr;
@@ -18,6 +20,7 @@ void loadPBSettings(const char name[], const unsigned sr, const unsigned c, cons
 snd_pcm_t * playbackSetup() {
 	snd_pcm_hw_params_t *hw_params;
 	static snd_pcm_t *pb_handle;
+        int err;
 
 	if ((err = snd_pcm_open(&pb_handle, hwpb.name, SND_PCM_STREAM_PLAYBACK, 0)) < 0) {
 		fprintf(stderr, "[ERROR:] cannot open audio device %s (%s)\n", hwpb.name, snd_strerror(err));


### PR DESCRIPTION
variables to be reused across different .c modules must be declared as 'extern' in header files, then defined (without 'extern') in the respective .c module files, otherwise you get them defined in multiple .o files and the linker complains